### PR TITLE
Add more wallets + loading + better messaging + feedback

### DIFF
--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -35,9 +35,9 @@ const TIMEOUT_TIME = 90000 // 1.5min
 
 const ERROR_ADD_MANUALLY_MESSAGE = 'There was an error adding the RPC automatically to your wallet. Please add manually'
 
-function getErrorMessage(error: any) {
+function getErrorMessage(error: any): string | null {
   if (error === NotConnectedError) {
-    return 'Please connect your wallet'
+    return null
   }
 
   if (error?.code === 4001) {
@@ -83,7 +83,13 @@ export function AddRpcButton() {
         console.error('[AddRpcButton] Error adding RPC to Wallet', error)
 
         const message = getErrorMessage(error)
-        setState({ state: 'error', errorMessage: message })
+        if (message === null) {
+          // The user is connecting
+          setState(DEFAULT_STATE)
+        } else {
+          // Display the error
+          setState({ state: 'error', errorMessage: message })
+        }
       })
       .finally(clearTimeouts)
 

--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -44,7 +44,7 @@ export function AddRpcButton() {
         } else {
           setState(AddRpcState.ERROR_ADDING)
         }
-      }) // TODO: Handle by open Raimbow Wallet :) 
+      }) 
   }, [addRpcEndpoint])
 
   // TODO: Disabled, for now to just go for injected wallet. Will probably improve and use it to support Wallet Connect and other wallets

--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -9,7 +9,7 @@ import { darken, transparentize } from "polished";
 import { useConnect } from "@src/hooks/useConnect";
 
 
-const Message = styled.p<{state: string }>`
+const Message = styled.p<{state: AddToWalletStateValues }>`
   color: ${({state}) => state === 'added' ? darken(0.3, Color.green) : Color.orange};
   font-weight: bold;
   width: 100%;

--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -30,7 +30,7 @@ const DEFAULT_STATE: AddToWalletState = { state: 'unknown' }
 const ADDING_STATE: AddToWalletState = { state: 'adding' }
 const ADDED_STATE: AddToWalletState = { state: 'added' }
 
-const TAKING_TOO_LONG_TIME = 10000 // 10s
+const TAKING_TOO_LONG_TIME = 15000 // 10s
 const TIMEOUT_TIME = 90000 // 1.5min
 
 const ERROR_ADD_MANUALLY_MESSAGE = 'There was an error adding the RPC automatically to your wallet. Please add manually'

--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -1,80 +1,102 @@
 import { BigButton } from "./Button";
 // import { ConnectButton, useConnectModal } from "@rainbow-me/rainbowkit";
-import { useAddRpcEndpoint } from "@src/hooks/useAddRpcEndpoint";
+import { NotConnectedError, useAddRpcEndpoint } from "@src/hooks/useAddRpcEndpoint";
 import { Confetti } from "./Confetti";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import styled from 'styled-components'
 import { Color } from "@src/const/styles/variables";
-import { transparentize, darken } from "polished";
+import { darken, transparentize } from "polished";
+import { useConnect } from "@src/hooks/useConnect";
 
 
-enum AddRpcState {
-  UNKNOWN,
-  ADDED,
-  ERROR_ADDING,
-  REJECTED_BY_USER
-}
-
-const Message = styled.p<{messageType: AddRpcState}>`
-  color: ${({messageType}) => messageType === AddRpcState.ADDED ? darken(0.3, Color.green) : Color.orange};
+const Message = styled.p<{state: string }>`
+  color: ${({state}) => state === 'added' ? darken(0.3, Color.green) : Color.orange};
   font-weight: bold;
   width: 100%;
   margin: 2.4rem 0 0;
-  background: ${({messageType}) => messageType === AddRpcState.ADDED ? transparentize(0.8, Color.green) : transparentize(0.9, Color.orange)};
+  background: ${({state}) => state === 'added' ? transparentize(0.8, Color.green) : transparentize(0.9, Color.orange)};
   padding: 1rem;
   border-radius: 1.2rem;
   text-align: center;
 `
 
-export function AddRpcButton() {
-  const { addRpcEndpoint } = useAddRpcEndpoint()
-  const [state, setState ] = useState<AddRpcState>(AddRpcState.UNKNOWN)
+interface AddToWalletState {
+  state: 'unknown' | 'adding' | 'added' | 'error' | 'takingTooLong',
+  errorMessage?: string
+}
+
+const DEFAULT_STATE: AddToWalletState = { state: 'unknown' }
+const ADDING_STATE: AddToWalletState = { state: 'adding' }
+const ADDED_STATE: AddToWalletState = { state: 'added' }
+const TAKING_TOO_LONG_TIME = 2000
+
+function getErrorMessage(error: any) {
+  if (error === NotConnectedError) {
+    return 'Please connect your wallet'
+  }
+
+  if (error?.code === 4001) {
+    return `The new network couldn't be added. Rejected by user`
+  }
+
+  if (error?.code === -32002 && error?.message?.includes('already pending')) {
+    return `Your wallet has a pending request to add the network. Please review your wallet.`
+  }
   
-  // const { openConnectModal } = useConnectModal()
+  return 'There was an error adding the RPC automatically to your wallet. Please add manually'
+}
+
+export function AddRpcButton() {
+  const { isConnected } = useConnect();
+  const { addRpcEndpoint } = useAddRpcEndpoint()
+  const [{ state, errorMessage }, setState ] = useState<AddToWalletState>(DEFAULT_STATE)
+  const isAdding = state === 'adding'
 
   const addToWallet = useCallback(() => {
-    setState(AddRpcState.UNKNOWN)
+    if (isAdding) {
+      return undefined
+    }
+
+    console.log('[addToWallet] Add to wallet')
+    setState(ADDING_STATE)
+
+    // Show a message if it takes long to connect/add-network
+    const timeoutId = setTimeout(() => {
+      const errorMessage = (isConnected ? 'Connecting to your wallet' : 'Adding the new network to your wallet') + ' is taking too long. Please verify your wallet'
+      setState({ state: 'adding', errorMessage })
+    }, TAKING_TOO_LONG_TIME)
+
     addRpcEndpoint()
-      .then(() => setState(AddRpcState.ADDED))
+      .then(() => setState(ADDED_STATE))
       .catch(error => {
         console.error('[AddRpcButton] Error adding RPC to Wallet', error)
 
-        if (error?.code === 4001) {
-          setState(AddRpcState.REJECTED_BY_USER)
-        } else {
-          setState(AddRpcState.ERROR_ADDING)
-        }
-      }) 
-  }, [addRpcEndpoint])
+        const message = getErrorMessage(error)
+        setState({ state: 'error', errorMessage: message })
+      })
+      .finally(() => clearTimeout(timeoutId))
 
-  // TODO: Disabled, for now to just go for injected wallet. Will probably improve and use it to support Wallet Connect and other wallets
-  // if (!isConnected) {
-  //   <ConnectButton
-  //     label="Connect Wallet"
-  //     accountStatus={"avatar"}
-  //     chainStatus={"none"}
-  //     showBalance={false}
-  //   />
-  // }
+      return () => clearTimeout(timeoutId)
+  }, [addRpcEndpoint, isConnected, isAdding])
 
-
-  // const addedRpc = state === AddRpcState.ADDED
+  // useEffect(() => {
+  //   if (isConnected && state === 'unknown') {
+  //     addToWallet()
+  //   }
+  // }, [isConnected, addToWallet, state])
 
   return (
     <>
-      {state === AddRpcState.ADDED ? (
+      {state === 'added' ? (
         <>
         <Confetti start={true} />
-        <Message messageType={state}>Added to your wallet! You are now safe</Message>
+        <Message state={state}>Added to your wallet! You are now safe</Message>
         </>
       ) : (
         <>
-          <BigButton onClick={addToWallet} label="Add to Wallet" />
-          {state === AddRpcState.REJECTED_BY_USER && (
-            <Message messageType={state}>The new network couldn&apos;t be added. Rejected by user</Message>
-          )}
-          {state === AddRpcState.ERROR_ADDING && (
-            <Message messageType={state}>There was an error adding the RPC automatically to your wallet. Please add manually</Message>
+          <BigButton onClick={addToWallet} label={isAdding? "Addding to Wallet..." : "Add to Wallet"} disabled={isAdding} />
+          {errorMessage && (
+            <Message state={state}>{errorMessage}</Message>
           )}
         </>
       )}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { transparentize } from "polished";
 import { Defaults, Color, Font, Media } from "@src/const/styles/variables";
 
@@ -80,10 +80,11 @@ type BigButtonProps = {
   label: string;
   target?: string;
   rel?: string;
+  disabled: boolean
   onClick?: () => void;
 };
 
-const BigButtonWrapper = styled.a`
+const BigButtonWrapper = styled.a<{disabled: boolean}>`
   text-align: center;
   line-height: 1;
   border: 0.2rem solid ${Color.black};
@@ -93,19 +94,28 @@ const BigButtonWrapper = styled.a`
   text-decoration: none;
   box-shadow: 0.3rem 0.3rem 0 ${Color.black};
   border-radius: 5px;
-  background: ${Color.orange};
   color: ${Color.black};
   display: inline-block;
   cursor: pointer;
-
-  &:hover {
-    top: 0.4rem;
-    left: 0.4rem;
-    box-shadow: 0.1rem 0.1rem 0 ${Color.black};
-    transition-property: box-shadow, top, left;
-    transition-duration: 0.3s;
-    transition-timing-function: ease-in-out;
-  }
+  
+  ${({ disabled }) => disabled ?
+    css`
+    color: gray;
+    border-color: gray;
+    cursor: not-allowed;
+    opacity: 0.5;
+    `:
+    css`
+    background: ${Color.orange};
+    &:hover {
+      top: 0.4rem;
+      left: 0.4rem;
+      box-shadow: 0.1rem 0.1rem 0 ${Color.black};
+      transition-property: box-shadow, top, left;
+      transition-duration: 0.3s;
+      transition-timing-function: ease-in-out;
+    }
+    `}
 `;
 
 export function Button({
@@ -134,8 +144,8 @@ export function Button({
   );
 }
 
-export function BigButton({ label, href, target, rel, fontSize, onClick }: BigButtonProps) {
+export function BigButton({ label, href, target, rel, fontSize, onClick, disabled }: BigButtonProps) {
   return (
-    <BigButtonWrapper {...{ href, label, target, rel, fontSize, onClick }}>{label}</BigButtonWrapper>
+    <BigButtonWrapper {...{ href, label, target, rel, fontSize, onClick, disabled }}>{label}</BigButtonWrapper>
   )
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -80,7 +80,7 @@ type BigButtonProps = {
   label: string;
   target?: string;
   rel?: string;
-  disabled: boolean
+  disabled?: boolean
   onClick?: () => void;
 };
 

--- a/src/components/WalletProvider.tsx
+++ b/src/components/WalletProvider.tsx
@@ -7,7 +7,6 @@ import { mainnet, gnosis, goerli } from "wagmi/chains";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import { publicProvider } from "wagmi/providers/public";
 import { CONFIG } from "@src/const/meta";
-import { InjectedConnector } from "@wagmi/core";
 
 export function WalletProvider({ children }: PropsWithChildren) {
   const { chains, provider } = configureChains(
@@ -23,25 +22,16 @@ export function WalletProvider({ children }: PropsWithChildren) {
         priority: 1,
       }),
     ]
-  );
-
-  // const { connectors } = getDefaultWallets({
-  //   appName: CONFIG.title,
-  //   chains,
-  // });
+  )
+  
+  const { connectors } = getDefaultWallets({
+    appName: CONFIG.title,
+    chains,
+  });
 
   const wagmiClient = createClient({
     autoConnect: true,
-    // connectors,
-    connectors: [
-      new InjectedConnector({
-        chains,
-        options: {
-          name: 'Injected',
-          shimDisconnect: true,
-        },
-      })
-    ],
+    connectors,
     provider,
   });
 

--- a/src/hooks/useAddRpcEndpoint.ts
+++ b/src/hooks/useAddRpcEndpoint.ts
@@ -4,19 +4,38 @@ import { useConnect } from "./useConnect";
 import { useSigner } from "wagmi";
 import { isJsonRpcProvider } from "@src/utils/ethers";
 
+
+export const NotConnectedError = new Error('No connected to any provider')
+
 export function useAddRpcEndpoint() {
   const { isConnected, connect } = useConnect();
 
   const signer = useSigner();
   const provider = signer.data?.provider;
 
-  const addRpcEndpoint = useCallback(async () => {    
-    const connectedProvider = isConnected ? provider : (await connect()).provider
-
-    if (!isJsonRpcProvider(connectedProvider)) {
-      console.warn('[addRpcEndpoint] Not JSON Provider. Impossible to send wallet_addEthereumChain')
-      return undefined;
+  const addRpcEndpoint = useCallback(async () => {
+    const connectedProvider = await (async () => {
+      if (!isConnected) {
+        const connectResult = await connect()
+        return connectResult ? connectResult.provider : undefined
+      } else {
+        return provider
+      }
+    })()
+    
+    console.log('[useAddRpcEndpoint] connectedProvider', connectedProvider)
+    if (connectedProvider === undefined) {
+      throw NotConnectedError
     }
+    
+    if (!isJsonRpcProvider(connectedProvider)) {
+      throw {
+        code: 4200,
+        message: 'The Provider is not an RPC Provider. It does not support the requested method'
+      }
+    }
+
+    console.log('[useAddRpcEndpoint] It is a RPC provider. Sending wallet_addEthereumChain')
 
     const {
       chainName,

--- a/src/hooks/useConnect.ts
+++ b/src/hooks/useConnect.ts
@@ -1,15 +1,31 @@
 import { useAccount, useConnect as useConnectWagmi } from "wagmi";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 export function useConnect() {
   const { isConnected } = useAccount();
   const { connectAsync, connectors } = useConnectWagmi()
 
+  const [injectedConnector, hasInjectedProviderPromise] = useMemo(() => {
+    const connector = connectors.find(c => c.id === 'injected')
+
+    return [connector, connector.getProvider().then(p => !!p)]
+  }, [connectors])
+
+
+
   const connect = useCallback(async () => {
-    return connectAsync({
-      connector: connectors[0]
-    })
-  }, [connectAsync, connectors]);
+    const hasInjectedProvider = await hasInjectedProviderPromise
+    
+    // Tries to connect first with the injected wallet
+    if (hasInjectedProvider) {
+      return connectAsync({
+        connector: injectedConnector
+      })
+    }
+
+    alert('Not injected!')
+    return undefined    
+  }, [connectAsync, injectedConnector, hasInjectedProviderPromise]);
 
   return {
     isConnected,

--- a/src/hooks/useConnect.ts
+++ b/src/hooks/useConnect.ts
@@ -1,6 +1,8 @@
-import { useAccount, useConnect as useConnectWagmi } from "wagmi";
+import { useAccount, useConnect as useConnectWagmi } from "wagmi"
 import { useCallback, useMemo } from "react";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { ConnectResult, Provider } from '@wagmi/core';
+
 
 export function useConnect() {
   const { isConnected } = useAccount();
@@ -15,17 +17,23 @@ export function useConnect() {
 
 
 
-  const connect = useCallback(async () => {
+  const connect = useCallback(async (): Promise<ConnectResult<Provider | undefined>> => {
     const hasInjectedProvider = await hasInjectedProviderPromise
     
-    // Tries to connect first with the injected wallet
-    if (hasInjectedProvider) {
-      return connectAsync({
-        connector: injectedConnector
-      })
+    // Shows connect modal if there's no injected wallet
+    if (!hasInjectedProvider) {
+      console.log('[useConnect] No injected connector. Using connect modal')
+      openConnectModal()
+      return undefined      
     }
 
-    return openConnectModal()   
+
+    // Connects with injected wallet (if available)
+    console.log('[useConnect] Connect using injected wallet')
+    return connectAsync({
+      connector: injectedConnector
+    })
+    
   }, [connectAsync, injectedConnector, hasInjectedProviderPromise, openConnectModal]);
 
   return {

--- a/src/hooks/useConnect.ts
+++ b/src/hooks/useConnect.ts
@@ -1,8 +1,10 @@
 import { useAccount, useConnect as useConnectWagmi } from "wagmi";
 import { useCallback, useMemo } from "react";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 
 export function useConnect() {
   const { isConnected } = useAccount();
+  const { openConnectModal } = useConnectModal()
   const { connectAsync, connectors } = useConnectWagmi()
 
   const [injectedConnector, hasInjectedProviderPromise] = useMemo(() => {
@@ -23,9 +25,8 @@ export function useConnect() {
       })
     }
 
-    alert('Not injected!')
-    return undefined    
-  }, [connectAsync, injectedConnector, hasInjectedProviderPromise]);
+    return openConnectModal()   
+  }, [connectAsync, injectedConnector, hasInjectedProviderPromise, openConnectModal]);
 
   return {
     isConnected,


### PR DESCRIPTION
This PR adds some UX improvements for the message

**1. Better messaging!**
It will handle better some errors, or some case where the request to add the RPC is already pending in the wallet

**2. It will show a message when is taking you more than 10s to approve the request.** 
 This helps you understand the next step is in the wallet. Also, its helpful for wallet connect (so the user checks their phone)

**3. Add a timeout after 1.5 min**
It's possible we don't even get a response from the user, or the wallet connect message is lost!
The app seems broken if this is the case (it's pending forever)

This will show the error message to the user, reset the button, and encourage the user to add the network manually

**4. Show the "Adding..." state**
style the button, and change the label

**5. Add support for not injected wallets.**
Now available for your Safari :) 
It will open a modal so you select another wallet.

Tried Rainbow Wallet on Wallet Connect


## Example: Safari
https://user-images.githubusercontent.com/2352112/228297365-b6872798-65a1-410d-b292-c83a6f078dbe.mov


## Example: Metamask Timeout
The video is accelerated for illustration purposes

https://user-images.githubusercontent.com/2352112/228297498-b05d791f-63d5-4e27-9db5-bdc910dde953.mov



