### PR TITLE
Add Analytic events for FAQ, header, footer and external links

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import Link from 'next/link'
 import { Color, Media } from '@src/const/styles/variables'
+import { scrollToClickedElement } from '@src/lib/analytics/events';
 
 const Wrapper = styled.footer`
   display: flex;
@@ -55,9 +56,9 @@ export default function Footer({ siteConfig, menu }) {
   return (
     <Wrapper>
       <Menu>
-        {menu.length > 0 && <>{menu.map(({ id, title, url, target }) => (
+        {menu.length > 0 && <>{menu.map(({ id, title, url, target, onClick }) => (
           <li key={id}>
-            <Link href={url} target={target}>{title}</Link>
+            <Link href={url} target={target} onClick={onClick}>{title}</Link>
           </li>
         ))}</>}
         <li>©{titleShort} {currentYear}</li>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -7,6 +7,7 @@ import { transparentize } from 'polished'
 import { Defaults, Color, Font, Media } from '@src/const/styles/variables'
 import useMediaQuery from '@src/lib/hooks/useMediaQuery';
 import { InView } from 'react-intersection-observer'
+import { scrollToClickedElement } from '@src/lib/analytics/events';
 
 const mobileHeaderHeight = `7rem`;
 
@@ -244,7 +245,7 @@ export default function Header({ siteConfig, menu}) {
             <Menu className={menuVisible ? 'visible' : ""}>
               {menu.map(({ id, title, url, target, rel }) => (
                 <MenuItem key={id} isActive={currentRoute === url} onClick={isMobile ? handleClick : null}>
-                  <a href={url} target={target} rel={rel}>{title}</a>
+                  <a href={url} target={target} rel={rel} onClick={scrollToClickedElement}>{title}</a>
                 </MenuItem>
               ))}
               <CloseIcon onClick={handleClick} />

--- a/src/const/menu.ts
+++ b/src/const/menu.ts
@@ -1,14 +1,15 @@
 import { CONFIG } from '@src/const/meta'
+import { openExternalLinkClickedElement, scrollToAction, scrollToClickedElement } from '@src/lib/analytics/events'
 const {social} = CONFIG
 
 export const mainMenu = [
-  { id: 0, title: 'Get protected', url: '#rpc'},
+  { id: 0, title: 'Get protected', url: '#rpc' },
   { id: 1, title: 'FAQ', url: '#faq'},
 ]
 
 export const footerMenu = [
-  { id: 0, title: 'Get protected', url: '#rpc'},
-  { id: 1, title: 'FAQ', url: '#faq'},
-  {id: 2, title: 'Questions & Support', url: social.telegram.url, target: '_blank'},
+  { id: 0, title: 'Get protected', url: '#rpc', onClick: scrollToClickedElement },
+  { id: 1, title: 'FAQ', url: '#faq', onClick: scrollToClickedElement},
+  {id: 2, title: 'Questions & Support', url: social.telegram.url, target: '_blank', onClick: openExternalLinkClickedElement },
 ]
 

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,3 +1,4 @@
+import { MouseEvent } from "react";
 import { sendEvent } from "./index";
 import { Category } from "./types";
 
@@ -14,5 +15,41 @@ export function scrollToAction(label: string) {
     category: Category.SCROLL_TO,
     action: `scroll_to`,
     label
+  });
+}
+
+export function openExternalLink(url: string) {
+  sendEvent({
+    category: Category.EXTERNAL_LINK,
+    action: `follow_link`,
+    label: url
+  });
+}
+
+/**
+ * Triggers an analytic event of type scroll_to, with the text of the element that was cliked as the event's label
+ * @param event click event
+ */
+export function scrollToClickedElement(event: MouseEvent<HTMLElement>) {
+  const text = event.currentTarget.innerHTML
+  scrollToAction(text)
+}
+
+
+/**
+ * Triggers an analytic event of type scroll_to, with the text of the element that was cliked as the event's label
+ * @param event click event
+ */
+export function openExternalLinkClickedElement(event: MouseEvent<HTMLAnchorElement>) {
+  const href = event.currentTarget.href
+  openExternalLink(href)
+}
+
+
+export function expandFaqQuestion(question: string) {
+  sendEvent({
+    category: Category.FAQ,
+    action: `expand_question`,
+    label: question
   });
 }

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -12,6 +12,7 @@ const IS_CLIENT = typeof window !== "undefined";
 const googleAnalytics = new GoogleAnalyticsProvider();
 
 export function sendEvent(event: string | UaEventOptions, params?: any): void {
+  console.log('[analytics] sendEvent', event, params)
   googleAnalytics.sendEvent(event, params);
 }
 

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -1,4 +1,6 @@
 export enum Category {
   COPY_TO_CLIPBOARD = "COPY_TO_CLIPBOARD",
-  SCROLL_TO = 'SCROLL_TO'
+  SCROLL_TO = 'SCROLL_TO',
+  FAQ = 'FAQ',
+  EXTERNAL_LINK = 'EXTERNAL_LINK',
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@
 import { GetStaticProps } from 'next'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, MouseEventHandler, MouseEvent } from 'react'
 import Layout from '@src/components/Layout'
 import { CopyIcon } from '@src/const/styles/global'
 import { Section, SectionContent, SectionWrapper, CardWrapper, CardItem, USPWrapper, USPItem, HeroImage } from '@src/const/styles/pages/index'
@@ -12,11 +12,17 @@ import { FAQ_CONTENT, USP_CONTENT, RPC_DETAILS, BUILT_WITH_LOVE, TESTIMONIALS} f
 import { ShareButton } from '@src/components/ShareButton'
 
 import { CopyToClipboard } from 'react-copy-to-clipboard'
-import { copyToClipboardAction, scrollToAction } from '@src/lib/analytics/events'
+import { copyToClipboardAction, expandFaqQuestion, scrollToAction } from '@src/lib/analytics/events'
 import { AddRpcButton } from '@src/components/AddRpcButton'
 import { CONFIG } from '@src/const/meta'
 
 const DATA_CACHE_TIME_SECONDS = 5 * 60 // Cache 5min
+
+function expandFaq(event: MouseEvent<HTMLElement>) {
+  const question = event.currentTarget.innerHTML
+  console.log('[expandFaq]', question)
+  expandFaqQuestion(question)
+}
 
 export default function Home() {
   const router = useRouter()
@@ -139,7 +145,7 @@ const handleOnCopy = useCallback((title: string) => {
             <div className={'section_FAQ'}>
             {FAQ_CONTENT.map(({question, answer}, index) => (
               <details key={index}>
-                <summary>{question}</summary>
+                <summary onClick={expandFaq}>{question}</summary>
                 <div>{answer}</div>
               </details>
             ))}


### PR DESCRIPTION
## Add events for each of the questions on the FAQ
<img width="1562" alt="image" src="https://user-images.githubusercontent.com/2352112/228371251-eb0eeb9a-9db9-4f4e-9f60-3a771359d54a.png">

## Also for the Links in the header
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/2352112/228371137-c4a0a1a7-2175-4010-897b-f2ee409f594d.png">


## The Links in the footer
Same as above

## And the external link in the footer

> 🚨 maybe this one i should delete! I see Google analytics already send another one automatically

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/2352112/228371748-c5a591ab-6cc0-42ad-9e3f-ad6152499302.png">


