### PR TITLE
Handle error not allowing you to add the RPC network

### DIFF
--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -45,10 +45,17 @@ function getErrorMessage(error: any): { errorMessage: string | null, isUserRejec
     return { errorMessage: `MEV Blocker was not added. User rejected.`, isUserRejection: true, isError: false }
   }
 
-  if (error?.code === -32002 && error?.message?.includes('already pending')) {
+  const message = error?.message
+  if (error?.code === -32002 && message?.includes('already pending')) {
     return { errorMessage: `Your wallet has a pending request to add the network. Please review your wallet.`, isUserRejection: false, isError: true }
   }
-  
+
+  if (error?.code === -32000 && message?.includes('May not specify default')) {
+    // Metakas IOS don't allow you to replace your RPC Endpoint
+    // https://community.metamask.io/t/allow-to-add-switch-between-ethereum-networks-using-api/23595
+    return { errorMessage: `Your wallet don't allow you to change your RPC so you can be protected 😢. It would be nice you let them know your thoughts!`, isUserRejection: false, isError: true }
+  }
+
   return { errorMessage: ERROR_ADD_MANUALLY_MESSAGE, isUserRejection: false, isError: true }
 }
 

--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -56,7 +56,7 @@ function getErrorMessage(error: any): { errorMessage: string | null, isUserRejec
   ) {
     // Metakas IOS don't allow you to replace your RPC Endpoint
     // https://community.metamask.io/t/allow-to-add-switch-between-ethereum-networks-using-api/23595
-    return { errorMessage: `Your wallet don't allow you to change your RPC so you can be protected 😢. It would be nice you let them know your thoughts!`, isUserRejection: false, isError: true }
+    return { errorMessage: `Oh no! 😢 It looks like your wallet doesn't support automatic RPC changes to help protect you. You might be able to make the change manually, though. If you could let your wallet provider know about this, that would be awesome! Thanks for considering it!`, isUserRejection: false, isError: true }
   }
 
   return { errorMessage: ERROR_ADD_MANUALLY_MESSAGE, isUserRejection: false, isError: true }

--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -50,7 +50,10 @@ function getErrorMessage(error: any): { errorMessage: string | null, isUserRejec
     return { errorMessage: `Your wallet has a pending request to add the network. Please review your wallet.`, isUserRejection: false, isError: true }
   }
 
-  if (error?.code === -32000 && message?.includes('May not specify default')) {
+  if (error?.code === -32000 && (
+    message?.includes('May not specify default') || // i.e. IOS Metamask
+    message?.includes('Chain ID already exists. Received')) // i.e. Im token
+  ) {
     // Metakas IOS don't allow you to replace your RPC Endpoint
     // https://community.metamask.io/t/allow-to-add-switch-between-ethereum-networks-using-api/23595
     return { errorMessage: `Your wallet don't allow you to change your RPC so you can be protected 😢. It would be nice you let them know your thoughts!`, isUserRejection: false, isError: true }


### PR DESCRIPTION
This PR handles the special case where some wallets don't allow you to use a different RPC node for Mainnet.

It will show a different message, inviting the user to ask for the feature to their Wallet. 
![image](https://user-images.githubusercontent.com/2352112/228519159-42b7d156-1fdb-4118-90bb-0d2bcb3646f6.png)


Partial fix for https://github.com/mevblocker/web/issues/24

## Context
https://cowservices.slack.com/archives/C04UG6HF726/p1680086604508549

## Test
Test in Metamask IOS and observe the new message