### PR TITLE
Handle error with imtoken too

### DIFF
--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -49,7 +49,10 @@ function getErrorMessage(error: any): string | null {
     return `Your wallet has a pending request to add the network. Please review your wallet.`
   }
 
-  if (error?.code === -32000 && message?.includes('May not specify default')) {
+  if (error?.code === -32000 && (
+    message?.includes('May not specify default') || // i.e. IOS Metamask
+    message?.includes('Chain ID already exists. Received')) // i.e. Im token
+  ) {
     // Metakas IOS don't allow you to replace your RPC Endpoint
     // https://community.metamask.io/t/allow-to-add-switch-between-ethereum-networks-using-api/23595
     return `Your wallet does't allow you to automatically change your RPC so you can be protected 😢. You might be able to do it manually. Please, consider letting them know about this!`


### PR DESCRIPTION
Same as https://github.com/mevblocker/web/pull/25 but this time handles the issue with Im token

This PR handles the special case where some wallets don't allow you to use a different RPC node for Mainnet.

It will show a different message, inviting the user to ask for the feature to their Wallet. 
![image](https://user-images.githubusercontent.com/2352112/228511937-784e4d4f-db0d-4e47-a0a9-c01830504c4d.png)

Partial fix for https://github.com/mevblocker/web/issues/24

## Context
https://cowservices.slack.com/archives/C04UG6HF726/p1680086604508549

## Test
Test in Metamask IOS and observe the new message