### PR TITLE
Improve error for Metamask in-app browser

### DIFF
--- a/src/components/AddRpcButton.tsx
+++ b/src/components/AddRpcButton.tsx
@@ -34,38 +34,49 @@ const ADDED_STATE: AddToWalletState = { state: 'added' }
 const TAKING_TOO_LONG_TIME = 15000 // 10s
 const TIMEOUT_TIME = 90000 // 1.5min
 
-const ERROR_ADD_MANUALLY_MESSAGE = 'There was an error adding the RPC automatically to your wallet. Please add manually'
+const ERROR_USER_REJECTED = { errorMessage: `MEV Blocker was not added. User rejected.`, isUserRejection: true, isError: false }
+const ERROR_ADD_MANUALLY_MESSAGE = { errorMessage: 'There was an error adding the RPC automatically to your wallet. Please add manually', isUserRejection: false, isError: true }
+const ERROR_NETWORK_ADDING_UNSUPPORTED = { errorMessage: `Oh no! 😢 It looks like your wallet doesn't support automatic RPC changes to help protect you. You might be able to make the change manually, though. If you could let your wallet provider know about this, that would be awesome! Thanks for considering it!`, isUserRejection: false, isError: true }
+const ERROR_NETWORK_ALREADY_ADDED = { errorMessage: `Your wallet has a pending request to add the network. Please review your wallet.`, isUserRejection: false, isError: true }
 
 function getErrorMessage(error: any): { errorMessage: string | null, isUserRejection: boolean, isError: boolean } {
-  if (error === NotConnectedError) {
-    return { errorMessage: null, isUserRejection: false, isError: false }
-  }
 
   if (error?.code === 4001) {
-    return { errorMessage: `MEV Blocker couldn't be added because you rejected the prompt. Please try again.`, isUserRejection: true, isError: false }
+    return ERROR_USER_REJECTED
   }
+
+  // -------- Uncomment to debug
+  // if (error) {
+  //   return { errorMessage: JSON.stringify(error, null, 2), isUserRejection: false, isError: true } 
+  // }
+  // -----------------
 
   const message = error?.message
   if (error?.code === -32002 && message?.includes('already pending')) {
-    return { errorMessage: `Your wallet has a pending request to add the network. Please review your wallet.`, isUserRejection: false, isError: true }
+    return ERROR_NETWORK_ALREADY_ADDED
   }
 
   if (error?.code === -32000 && (
-    message?.includes('May not specify default') || // i.e. IOS Metamask
+    message?.includes('May not specify default') || // i.e. IOS Metamask (over Wallet Connect)
     message?.includes('Chain ID already exists. Received')) // i.e. Im token
   ) {
-    // Metakas IOS don't allow you to replace your RPC Endpoint
-    // https://community.metamask.io/t/allow-to-add-switch-between-ethereum-networks-using-api/23595
-    return { errorMessage: `Oh no! 😢 It looks like your wallet doesn't support automatic RPC changes to help protect you. You might be able to make the change manually, though. If you could let your wallet provider know about this, that would be awesome! Thanks for considering it!`, isUserRejection: false, isError: true }
+    return ERROR_NETWORK_ADDING_UNSUPPORTED
   }
 
-  return { errorMessage: ERROR_ADD_MANUALLY_MESSAGE, isUserRejection: false, isError: true }
+  if (error?.code === -32602 && message?.includes('May not specify default')){
+    // Metakas IOS don't allow you to replace your RPC Endpoint
+    // https://community.metamask.io/t/allow-to-add-switch-between-ethereum-networks-using-api/23595
+    return ERROR_NETWORK_ADDING_UNSUPPORTED
+  }
+
+  return ERROR_ADD_MANUALLY_MESSAGE
 }
 
 export function AddRpcButton() {
   const { addRpcEndpoint } = useAddRpcEndpoint()
   const [{ state, errorMessage }, setState] = useState<AddToWalletState>(DEFAULT_STATE)
   const isAdding = state === 'adding'
+  
 
   const addToWallet = useCallback(() => {
     if (isAdding) {
@@ -87,7 +98,7 @@ export function AddRpcButton() {
 
     // Gives some feedback if it takes long, plus add some timeout
     const timeoutSlow = delayMessage('Adding the new network to your wallet is taking too long. Please verify your wallet', 'adding', TAKING_TOO_LONG_TIME, 'adding_is_taking_too_long')
-    const timeoutTimeout = delayMessage(ERROR_ADD_MANUALLY_MESSAGE, 'error', TIMEOUT_TIME, 'timeout_add_rpc')
+    const timeoutTimeout = delayMessage(ERROR_ADD_MANUALLY_MESSAGE.errorMessage, 'error', TIMEOUT_TIME, 'timeout_add_rpc')
     const clearTimeouts = () => [timeoutSlow, timeoutTimeout].forEach(clearTimeout)
 
     addRpcEndpoint()


### PR DESCRIPTION
Add a better message for Metamask in-app browser


Aparently Metamask in-app browswe response for adding the network return a different code and message than the SAME app using Wallet Connect. 

This PR just makes sure we handle the error message better to show the following message:

![image](https://user-images.githubusercontent.com/2352112/229235964-66fc154c-2a28-41f7-907d-c067ff2a9e0c.png)

## Test
- Try to add the network in Metmask
- Make sure we show this message
