### PR TITLE
Content page table styles

### DIFF
--- a/src/const/menu.ts
+++ b/src/const/menu.ts
@@ -16,8 +16,8 @@ export const footerMenu = [
   },
   {
     label: 'About', links: [      
-      {id: 0, title: 'Terms and Conditions', url: 'https://swap.cow.fi/#/terms-and-conditions', type: 'external' },
-      {id: 1, title: 'Privacy Policy', url: 'https://swap.cow.fi/#/privacy-policy', type: 'external' },
+      {id: 0, title: 'Terms and Conditions', url: 'https://swap.cow.fi/#/terms-and-conditions', target: '_blank' },
+      {id: 1, title: 'Privacy Policy', url: 'https://swap.cow.fi/#/privacy-policy', target: '_blank' },
       {id: 2, title: 'Cookie Policy', url: `${CONFIG.url.cookiePolicy}`},
     ]
   },

--- a/src/const/styles/pages/index.ts
+++ b/src/const/styles/pages/index.ts
@@ -97,14 +97,21 @@ export const SectionContent = styled.div<{ maxWidth?: number; align?: string }>`
   }
 
   table {
+    width: 100%;
     border-spacing: 1px;
     font-size: 16px;
     line-height: 1.5;
+    position: relative;
+
+    ${Media.mobile} {
+      display: block;
+      overflow-x: auto;
+      white-space: nowrap;
+      max-width: 100%;
+    }
 
     th,
     td {
-      min-width: 200px;
-      text-align: left !important;
       padding: 6px 12px;
 
       &:not(:first-child) {
@@ -114,6 +121,17 @@ export const SectionContent = styled.div<{ maxWidth?: number; align?: string }>`
 
     th {
       padding: 16px 12px;
+    }
+
+    > thead > tr {
+      background: ${transparentize(0.2, Color.text1)};
+      color: ${Color.white};
+    }
+
+    > tbody > tr {
+      &:nth-child(even) {
+        background: ${transparentize(0.95, Color.text1)};
+      }
     }
   }
 


### PR DESCRIPTION
- Styles <table> elements on content pages
- On mobile/small viewports introduces horizontal scrolling for the table
- Added target `_blank` for some footer links


https://user-images.githubusercontent.com/31534717/234004090-fe1cc4d1-7a90-48b2-82b8-f307dfe3c524.mov

<img width="997" alt="Screenshot 2023-04-24 at 13 50 08" src="https://user-images.githubusercontent.com/31534717/234004125-59417856-ff3f-4c81-bad4-1ec402d0bdb6.png">
