### PR TITLE
Updates point 3 for the new channges

### DIFF
--- a/src/const/docs.md
+++ b/src/const/docs.md
@@ -23,7 +23,7 @@ Response:
 3. You'll start receiving unsigned pending transactions (missing `v`, `r`, and `s`):
 
 ```
-{"jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xd58bbbc0f5190962eff01b6f0ec17724", "result": {"chainId": 1, "to": "0xe33062a24149f7801a48b2675ed5111d3278f0f5", "value": "0x0", "data": "0x", "nonce": "0x1006", "maxPriorityFeePerGas": "0x10c8f83", "maxFeePerGas": "0x1307bf2380", "gas": "0x5208", "type": 2, "hash": "0x272ef23fc2c1ae118a1d0ba7203fa0ec8663e4991cc96a1338d4534383dffcdc", "from": "0xe33062a24149f7801a48b2675ed5111d3278f0f5"}}}
+{"jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xd58bbbc0f5190962eff01b6f0ec17724", "result": {"chainId": "0x1", "to": "0x6215589d293fdf52886484f46f0d6a11c76b4a7e", "value": "0x4fefa17b724000", "data": "0x", "accessList": [], "nonce": "0x10", "maxPriorityFeePerGas": "0x0", "maxFeePerGas": "0x7e1c65b04", "gas": "0x5208", "type": "0x2", "hash": "0x5f08dd372fce1a44dda27bed60ca036acb4979fad6ca37b9c388e351a870fe4c", "from": "0xcb1588f3f7e92a1278c68a6aed4bdcbc68534b29"}}}
 ```
 
 4. Construct a back-run bundle just like you would for a target transaction from the mempool, but make the first element of the `txs` array in `params` of `eth_sendBundle` the hash of the pending target, instead of the fully-encoded transaction


### PR DESCRIPTION
Updates the documentation to reflect the change for adding accessList since some transactions completely change behaviour (https://help.safe.global/en/articles/5249851-why-can-t-i-transfer-eth-from-a-contract-into-a-safe) without it.