### PR TITLE
feat: add index.html for MEV Blocker redirection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MEV Blocker - Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=https://cow.fi/mev-blocker" />
+    <link rel="canonical" href="https://cow.fi/mev-blocker" />
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        margin: 0;
+        background: #48bdff;
+        text-align: center;
+      }
+      .container {
+        max-width: 500px;
+        padding: 2rem;
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 16px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+      }
+      h1 {
+        color: #000000;
+        margin-bottom: 1rem;
+      }
+      p {
+        color: #000000;
+        margin-bottom: 1.5rem;
+      }
+      .spinner {
+        border: 3px solid black;
+        border-top: 3px solid #ffffff;
+        border-radius: 50%;
+        width: 30px;
+        height: 30px;
+        animation: spin 1s linear infinite;
+        margin: 0 auto 1rem;
+      }
+      @keyframes spin {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+      a {
+        color: #000000;
+        text-decoration: underline;
+        font-weight: 600;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="spinner"></div>
+      <h1>MEV Blocker</h1>
+      <p>You are being redirected to the new MEV Blocker page...</p>
+      <p>
+        If you are not redirected automatically,
+        <a href="https://cow.fi/mev-blocker">click here</a>.
+      </p>
+    </div>
+
+    <script>
+      // JavaScript fallback for immediate redirect
+      setTimeout(function () {
+        window.location.href = "https://cow.fi/mev-blocker"
+      }, 100)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Add static HTML redirect to cow.fi/mev-blocker

Adds `public/index.html` with immediate meta refresh redirect to maintain current redirect behavior while allowing feature branches to work without redirects. This allows time to remove platform-level Vercel redirects without breaking functionality.