### PR TITLE
Update documentation link

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,7 +18,7 @@ const nextConfig = {
       {
         source: "/docs",
         destination:
-          "https://docs.cow.fi/mevblocker?utm_source=cow.fi&utm_medium=web&utm_content=mev-blocker-docs-link",
+          "https://docs.mevblocker.io?utm_source=mevblocker.io&utm_medium=web&utm_content=mev-blocker-docs-link",
         permanent: false,
       },
     ]

--- a/src/const/meta.ts
+++ b/src/const/meta.ts
@@ -20,7 +20,7 @@ export const CONFIG = {
     home: "/",
     faq: "#faq",
     rpc: "#rpc",
-    docs: "https://docs.cow.fi/mevblocker?utm_source=cow.fi&utm_medium=web&utm_content=mev-blocker-docs-link",
+    docs: "https://docs.mevblocker.io?utm_source=mevblocker.io&utm_medium=web&utm_content=mev-blocker-docs-link",
     cowSwap: "https://swap.cow.fi",
     cowProtocol: "https://cow.fi",
     beaver: "https://beaverbuild.org/",

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
   return {
     redirect: {
       destination:
-        "https://docs.cow.fi/mevblocker?utm_source=cow.fi&utm_medium=web&utm_content=mev-blocker-docs-link",
+        "https://docs.mevblocker.io?utm_source=mevblocker.io&utm_medium=web&utm_content=mev-blocker-docs-link",
       permanent: false,
     },
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -155,7 +155,7 @@ export default function Home() {
           <p>USD value of median rebate</p>
         </MetricsItem>
         <MetricsLink
-          href="https://dune.com/cowprotocol/mev-blocker?utm_source=mevblocker.io&utm_medium=web&utm_content=mev-blocker-metrics-link"
+          href="https://dune.com/cowprotocol/mev-blocker?utm_source=cow.fi&utm_medium=web&utm_content=mev-blocker-metrics-link"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -155,7 +155,7 @@ export default function Home() {
           <p>USD value of median rebate</p>
         </MetricsItem>
         <MetricsLink
-          href="https://dune.com/cowprotocol/mev-blocker?utm_source=cow.fi&utm_medium=web&utm_content=mev-blocker-metrics-link"
+          href="https://dune.com/cowprotocol/mev-blocker?utm_source=mevblocker.io&utm_medium=web&utm_content=mev-blocker-metrics-link"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -288,7 +288,7 @@ export default function Home() {
               To learn more about each of the endpoints MEV Blocker has to
               offer,{" "}
               <a
-                href="https://docs.cow.fi/mevblocker?utm_source=cow.fi&utm_medium=web&utm_content=mev-blocker-docs-link"
+                href="https://docs.mevblocker.io?utm_source=mevblocker.io&utm_medium=web&utm_content=mev-blocker-docs-link"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
This PR updates all MEV Blocker documentation links from `docs.cow.fi/mevblocker` to `https://docs.mevblocker.io` while preserving existing UTM parameters and switching `utm_source` to `mevblocker.io`. It also updates `/docs` redirects (Next.js redirect + SSR redirect) to point to the new docs URL.

**This PR should only be merged once the new docsite goes live**.